### PR TITLE
Parameterize timeout

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,8 +12,10 @@ driver:
 provisioner:
   name: chef_zero
   nodes_path: 'test/fixtures/nodes'
-  data_bags_path: 'test/fixtures/data_bags'
-  environments_path: 'test/fixtures/environments'
+  data_bags_path: '../../avvo_chef/data_bags'
+  environments_path: '../../avvo_chef/environments'
+  roles_path: '../../avvo_chef/roles'
+
   client_rb:
     environment: _default
   attributes:
@@ -21,69 +23,26 @@ provisioner:
       jdk_version: '8'
 
 platforms:
-  - name: ubuntu-16.04
-    run_list:
-    - recipe[apt]
-    - recipe[curl]
-    - recipe[java]
-    - recipe[elasticsearch_test::fix_cacerts]
   - name: ubuntu-14.04
     run_list:
     - recipe[apt]
     - recipe[curl]
     - recipe[java]
-    - recipe[elasticsearch_test::fix_cacerts]
-  - name: ubuntu-12.04
-    run_list:
-    - recipe[apt]
-    - recipe[curl]
-    - recipe[java]
-    - recipe[elasticsearch_test::fix_cacerts]
-  - name: centos-7.2
-    run_list:
-    - recipe[yum]
-    - recipe[curl]
-    - recipe[java]
-  - name: centos-6.7
-    run_list:
-    - recipe[yum]
-    - recipe[curl]
-    - recipe[java]
-
 suites:
-  - name: repository # install from repository
+  - name: default
     run_list:
-      - recipe[elasticsearch_test::default_with_plugins]
+      - recipe[elasticsearch]
     attributes:
       elasticsearch:
+        service:
+          startup_method: init
+          path_conf: "/srv/elasticsearch"
         install:
-          type: repository
-
-  - name: tarball # install by tarball
-    run_list:
-      - recipe[elasticsearch_test::default_with_plugins]
-    attributes:
-      elasticsearch:
-        install:
-          type: tarball
-
-  - name: package # install from package directly
-    run_list:
-      - recipe[java]
-      - recipe[elasticsearch_test::default_with_plugins]
-    attributes:
-      elasticsearch:
-        install:
-          type: package
-
-  - name: doubleinstance
-    run_list:
-      - recipe[elasticsearch_test::doubleinstances]
-
-  - name: override_package # the override-everything use case
-    run_list:
-      - recipe[elasticsearch_test::package]
-
-  - name: override_tarball # the override-everything use case
-    run_list:
-      - recipe[elasticsearch_test::tarball]
+          version: 5.6.3
+        configure: 
+          instance_name: "elasticsearch"
+          allocated_memory: "244m"
+          path_conf: "/srv/elasticsearch"
+          path_logs: "/var/log/elasticsearch"
+          path_pid: "/var/run/elasticsearch"
+          path_plugins: "/usr/share/elasticsearch/plugins"

--- a/libraries/provider_service.rb
+++ b/libraries/provider_service.rb
@@ -37,7 +37,8 @@ class ElasticsearchCookbook::ServiceProvider < Chef::Provider::LWRPBase
         mode '0755'
         variables(
           # we need to include something about #{progname} fixed in here.
-          program_name: new_resource.service_name
+          program_name: new_resource.service_name,
+          startup_timeout: node['elasticsearch']['service']['startup_timeout']
         )
         only_if { ::File.exist?('/etc/init.d') }
         action :nothing

--- a/libraries/resource_service.rb
+++ b/libraries/resource_service.rb
@@ -21,6 +21,7 @@ class ElasticsearchCookbook::ServiceResource < Chef::Resource::LWRPBase
   # allow overridable init script
   attribute(:init_source, kind_of: String, default: 'initscript.erb')
   attribute(:init_cookbook, kind_of: String, default: 'elasticsearch')
+  attribute(:startup_timeout, kind_of: String, default: '10')
 
   # allow overridable systemd unit
   attribute(:systemd_source, kind_of: String, default: 'systemd_unit.erb')

--- a/libraries/resource_service.rb
+++ b/libraries/resource_service.rb
@@ -21,9 +21,11 @@ class ElasticsearchCookbook::ServiceResource < Chef::Resource::LWRPBase
   # allow overridable init script
   attribute(:init_source, kind_of: String, default: 'initscript.erb')
   attribute(:init_cookbook, kind_of: String, default: 'elasticsearch')
-  attribute(:startup_timeout, kind_of: String, default: '10')
 
   # allow overridable systemd unit
   attribute(:systemd_source, kind_of: String, default: 'systemd_unit.erb')
   attribute(:systemd_cookbook, kind_of: String, default: 'elasticsearch')
+
+  # allow overridable startup_timeout for ubuntu/debian initscript templates
+  attribute(:startup_timeout, kind_of: String, default: '10')
 end

--- a/libraries/resource_service.rb
+++ b/libraries/resource_service.rb
@@ -11,6 +11,9 @@ class ElasticsearchCookbook::ServiceResource < Chef::Resource::LWRPBase
 
   # this is what helps the various resources find each other
   attribute(:instance_name, kind_of: String, default: nil)
+  attribute(:path_conf,    kind_of: String, default: '/etc/elasticsearch')
+  attribute(:path_data,    kind_of: String, default: '/var/lib/elasticsearch')
+  attribute(:path_logs,    kind_of: String, default: '/var/log/elasticsearch')
 
   attribute(:service_name, kind_of: String, name_attribute: true)
   attribute(:args, kind_of: String, default: '-d')
@@ -18,7 +21,13 @@ class ElasticsearchCookbook::ServiceResource < Chef::Resource::LWRPBase
   # service actions
   attribute(:service_actions, kind_of: [Symbol, String, Array], default: [:enable, :start].freeze)
 
+  attribute(:startup_method, kind_of: String, default: 'init')
+
   # allow overridable init script
+  attribute(:initd_source, kind_of: String, default: 'initdscript.erb')
+  attribute(:initd_cookbook, kind_of: String, default: 'elasticsearch')
+
+  # allow overridable upstart script
   attribute(:init_source, kind_of: String, default: 'initscript.erb')
   attribute(:init_cookbook, kind_of: String, default: 'elasticsearch')
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'karel.minarik@elasticsearch.org'
 license          'Apache 2.0'
 description      'Installs and configures Elasticsearch'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.4.1'
+version          '3.4.2'
 
 supports 'amazon'
 supports 'centos'

--- a/templates/debian/initscript.erb
+++ b/templates/debian/initscript.erb
@@ -156,7 +156,7 @@ case "$1" in
 	return=$?
 	if [ $return -eq 0 ]; then
 		i=0
-		timeout=10
+		timeout=<%= @startup_timeout %>
 		# Wait for the process to be properly started before exiting
 		until { kill -0 `cat "$PID_FILE"`; } >/dev/null 2>&1
 		do

--- a/templates/ubuntu/initdscript.erb
+++ b/templates/ubuntu/initdscript.erb
@@ -1,0 +1,210 @@
+#!/bin/bash
+#
+# /etc/init.d/<%= @program_name %> -- startup script for Elasticsearch
+#
+### BEGIN INIT INFO
+# Provides:          <%= @program_name %>
+# Required-Start:    $network $remote_fs $named
+# Required-Stop:     $network $remote_fs $named
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Starts elasticsearch
+# Description:       Starts elasticsearch using start-stop-daemon
+### END INIT INFO
+
+PATH=/bin:/usr/bin:/sbin:/usr/sbin
+NAME=<%= @program_name %>
+DESC="Elasticsearch Server"
+DEFAULT=/etc/default/$NAME
+
+if [ `id -u` -ne 0 ]; then
+	echo "You need root privileges to run this script"
+	exit 1
+fi
+
+
+. /lib/lsb/init-functions
+
+if [ -r /etc/default/rcS ]; then
+	. /etc/default/rcS
+fi
+
+
+# The following variables can be overwritten in $DEFAULT
+
+# Run Elasticsearch as this user ID and group ID
+ES_USER=elasticsearch
+ES_GROUP=elasticsearch
+
+# Directory where the Elasticsearch binary distribution resides
+ES_HOME=/usr/share/$NAME
+
+# Additional Java OPTS
+#ES_JAVA_OPTS=
+
+# Maximum number of open files
+MAX_OPEN_FILES=65536
+
+# Maximum amount of locked memory
+#MAX_LOCKED_MEMORY=
+
+# Elasticsearch log directory
+LOG_DIR=/var/log/$NAME
+
+# Elasticsearch data directory
+DATA_DIR=/var/lib/$NAME
+
+# Elasticsearch configuration directory
+CONF_DIR=/etc/$NAME
+
+# Maximum number of VMA (Virtual Memory Areas) a process can own
+MAX_MAP_COUNT=262144
+
+# Elasticsearch PID file directory
+PID_DIR="/var/run/elasticsearch"
+
+# End of variables that can be overwritten in $DEFAULT
+
+# overwrite settings from default file
+if [ -f "$DEFAULT" ]; then
+	. "$DEFAULT"
+fi
+
+if [ "$ES_USER" != "elasticsearch" ] || [ "$ES_GROUP" != "elasticsearch" ]; then
+    echo "WARNING: ES_USER and ES_GROUP are deprecated and will be removed in the next major version of Elasticsearch, got: [$ES_USER:$ES_GROUP]"
+fi
+
+# CONF_FILE setting was removed
+if [ ! -z "$CONF_FILE" ]; then
+    echo "CONF_FILE setting is no longer supported. elasticsearch.yml must be placed in the config directory and cannot be renamed."
+    exit 1
+fi
+
+# Define other required variables
+PID_FILE="$PID_DIR/$NAME.pid"
+DAEMON=$ES_HOME/bin/elasticsearch
+DAEMON_OPTS="-d -p $PID_FILE -Edefault.path.logs=$LOG_DIR -Edefault.path.data=$DATA_DIR -Edefault.path.conf=$CONF_DIR"
+
+export ES_JAVA_OPTS
+export JAVA_HOME
+export ES_INCLUDE
+export ES_JVM_OPTIONS
+
+# export unsupported variables so bin/elasticsearch can reject them and inform the user these are unsupported
+if test -n "$ES_MIN_MEM"; then export ES_MIN_MEM; fi
+if test -n "$ES_MAX_MEM"; then export ES_MAX_MEM; fi
+if test -n "$ES_HEAP_SIZE"; then export ES_HEAP_SIZE; fi
+if test -n "$ES_HEAP_NEWSIZE"; then export ES_HEAP_NEWSIZE; fi
+if test -n "$ES_DIRECT_SIZE"; then export ES_DIRECT_SIZE; fi
+if test -n "$ES_USE_IPV4"; then export ES_USE_IPV4; fi
+if test -n "$ES_GC_OPTS"; then export ES_GC_OPTS; fi
+if test -n "$ES_GC_LOG_FILE"; then export ES_GC_LOG_FILE; fi
+
+if [ ! -x "$DAEMON" ]; then
+	echo "The elasticsearch startup script does not exists or it is not executable, tried: $DAEMON"
+	exit 1
+fi
+
+checkJava() {
+	if [ -x "$JAVA_HOME/bin/java" ]; then
+		JAVA="$JAVA_HOME/bin/java"
+	else
+		JAVA=`which java`
+	fi
+
+	if [ ! -x "$JAVA" ]; then
+		echo "Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME"
+		exit 1
+	fi
+}
+
+case "$1" in
+  start)
+	checkJava
+
+	log_daemon_msg "Starting $DESC"
+
+	pid=`pidofproc -p $PID_FILE elasticsearch`
+	if [ -n "$pid" ] ; then
+		log_begin_msg "Already running."
+		log_end_msg 0
+		exit 0
+	fi
+
+	# Ensure that the PID_DIR exists (it is cleaned at OS startup time)
+	if [ -n "$PID_DIR" ] && [ ! -e "$PID_DIR" ]; then
+		mkdir -p "$PID_DIR" && chown "$ES_USER":"$ES_GROUP" "$PID_DIR"
+	fi
+	if [ -n "$PID_FILE" ] && [ ! -e "$PID_FILE" ]; then
+		touch "$PID_FILE" && chown "$ES_USER":"$ES_GROUP" "$PID_FILE"
+	fi
+
+	if [ -n "$MAX_OPEN_FILES" ]; then
+		ulimit -n $MAX_OPEN_FILES
+	fi
+
+	if [ -n "$MAX_LOCKED_MEMORY" ]; then
+		ulimit -l $MAX_LOCKED_MEMORY
+	fi
+
+	if [ -n "$MAX_MAP_COUNT" -a -f /proc/sys/vm/max_map_count ]; then
+		sysctl -q -w vm.max_map_count=$MAX_MAP_COUNT
+	fi
+
+	# Start Daemon
+	start-stop-daemon -d $ES_HOME --start --user "$ES_USER" -c "$ES_USER" --pidfile "$PID_FILE" --exec $DAEMON -- $DAEMON_OPTS
+	return=$?
+	if [ $return -eq 0 ]; then
+		i=0
+		timeout=<%= @startup_timeout %>
+		# Wait for the process to be properly started before exiting
+		until { kill -0 `cat "$PID_FILE"`; } >/dev/null 2>&1
+		do
+			sleep 1
+			i=$(($i + 1))
+			if [ $i -gt $timeout ]; then
+				log_end_msg 1
+				exit 1
+			fi
+		done
+	fi
+	log_end_msg $return
+	exit $return
+	;;
+  stop)
+	log_daemon_msg "Stopping $DESC"
+
+	if [ -f "$PID_FILE" ]; then
+		start-stop-daemon --stop --pidfile "$PID_FILE" \
+			--user "$ES_USER" \
+			--quiet \
+			--retry forever/TERM/20 > /dev/null
+		if [ $? -eq 1 ]; then
+			log_progress_msg "$DESC is not running but pid file exists, cleaning up"
+		elif [ $? -eq 3 ]; then
+			PID="`cat $PID_FILE`"
+			log_failure_msg "Failed to stop $DESC (pid $PID)"
+			exit 1
+		fi
+		rm -f "$PID_FILE"
+	else
+		log_progress_msg "(not running)"
+	fi
+	log_end_msg 0
+	;;
+  status)
+	status_of_proc -p $PID_FILE elasticsearch elasticsearch && exit 0 || exit $?
+	;;
+  restart|force-reload)
+	if [ -f "$PID_FILE" ]; then
+		$0 stop
+	fi
+	$0 start
+	;;
+  *)
+	log_success_msg "Usage: $0 {start|stop|restart|force-reload|status}"
+	exit 1
+	;;
+esac
+
+exit 0

--- a/templates/ubuntu/initscript.erb
+++ b/templates/ubuntu/initscript.erb
@@ -1,210 +1,23 @@
-#!/bin/bash
+# Elasticsearch - Elasticsearch Service
 #
-# /etc/init.d/<%= @program_name %> -- startup script for Elasticsearch
-#
-### BEGIN INIT INFO
-# Provides:          <%= @program_name %>
-# Required-Start:    $network $remote_fs $named
-# Required-Stop:     $network $remote_fs $named
-# Default-Start:     2 3 4 5
-# Default-Stop:      0 1 6
-# Short-Description: Starts elasticsearch
-# Description:       Starts elasticsearch using start-stop-daemon
-### END INIT INFO
+# Startup script for Elasticsearch
+# /etc/init/<%= @program_name %> 
 
-PATH=/bin:/usr/bin:/sbin:/usr/sbin
-NAME=<%= @program_name %>
-DESC="Elasticsearch Server"
-DEFAULT=/etc/default/$NAME
+description	"Elasticsearch Service"
 
-if [ `id -u` -ne 0 ]; then
-	echo "You need root privileges to run this script"
-	exit 1
-fi
+start on (net-device-up
+          and local-filesystems
+          and runlevel [2345])
+stop on runlevel [!2345]
 
+env ES_JVM_OPTIONS=<%= @path_conf %>/jvm.options
 
-. /lib/lsb/init-functions
+setuid <%= @es_user %>
+setgid <%= @es_group %>
 
-if [ -r /etc/default/rcS ]; then
-	. /etc/default/rcS
-fi
+limit nofile 32000 32000
 
+respawn
+respawn limit 10 30
 
-# The following variables can be overwritten in $DEFAULT
-
-# Run Elasticsearch as this user ID and group ID
-ES_USER=elasticsearch
-ES_GROUP=elasticsearch
-
-# Directory where the Elasticsearch binary distribution resides
-ES_HOME=/usr/share/$NAME
-
-# Additional Java OPTS
-#ES_JAVA_OPTS=
-
-# Maximum number of open files
-MAX_OPEN_FILES=65536
-
-# Maximum amount of locked memory
-#MAX_LOCKED_MEMORY=
-
-# Elasticsearch log directory
-LOG_DIR=/var/log/$NAME
-
-# Elasticsearch data directory
-DATA_DIR=/var/lib/$NAME
-
-# Elasticsearch configuration directory
-CONF_DIR=/etc/$NAME
-
-# Maximum number of VMA (Virtual Memory Areas) a process can own
-MAX_MAP_COUNT=262144
-
-# Elasticsearch PID file directory
-PID_DIR="/var/run/elasticsearch"
-
-# End of variables that can be overwritten in $DEFAULT
-
-# overwrite settings from default file
-if [ -f "$DEFAULT" ]; then
-	. "$DEFAULT"
-fi
-
-if [ "$ES_USER" != "elasticsearch" ] || [ "$ES_GROUP" != "elasticsearch" ]; then
-    echo "WARNING: ES_USER and ES_GROUP are deprecated and will be removed in the next major version of Elasticsearch, got: [$ES_USER:$ES_GROUP]"
-fi
-
-# CONF_FILE setting was removed
-if [ ! -z "$CONF_FILE" ]; then
-    echo "CONF_FILE setting is no longer supported. elasticsearch.yml must be placed in the config directory and cannot be renamed."
-    exit 1
-fi
-
-# Define other required variables
-PID_FILE="$PID_DIR/$NAME.pid"
-DAEMON=$ES_HOME/bin/elasticsearch
-DAEMON_OPTS="-d -p $PID_FILE -Edefault.path.logs=$LOG_DIR -Edefault.path.data=$DATA_DIR -Edefault.path.conf=$CONF_DIR"
-
-export ES_JAVA_OPTS
-export JAVA_HOME
-export ES_INCLUDE
-export ES_JVM_OPTIONS
-
-# export unsupported variables so bin/elasticsearch can reject them and inform the user these are unsupported
-if test -n "$ES_MIN_MEM"; then export ES_MIN_MEM; fi
-if test -n "$ES_MAX_MEM"; then export ES_MAX_MEM; fi
-if test -n "$ES_HEAP_SIZE"; then export ES_HEAP_SIZE; fi
-if test -n "$ES_HEAP_NEWSIZE"; then export ES_HEAP_NEWSIZE; fi
-if test -n "$ES_DIRECT_SIZE"; then export ES_DIRECT_SIZE; fi
-if test -n "$ES_USE_IPV4"; then export ES_USE_IPV4; fi
-if test -n "$ES_GC_OPTS"; then export ES_GC_OPTS; fi
-if test -n "$ES_GC_LOG_FILE"; then export ES_GC_LOG_FILE; fi
-
-if [ ! -x "$DAEMON" ]; then
-	echo "The elasticsearch startup script does not exists or it is not executable, tried: $DAEMON"
-	exit 1
-fi
-
-checkJava() {
-	if [ -x "$JAVA_HOME/bin/java" ]; then
-		JAVA="$JAVA_HOME/bin/java"
-	else
-		JAVA=`which java`
-	fi
-
-	if [ ! -x "$JAVA" ]; then
-		echo "Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME"
-		exit 1
-	fi
-}
-
-case "$1" in
-  start)
-	checkJava
-
-	log_daemon_msg "Starting $DESC"
-
-	pid=`pidofproc -p $PID_FILE elasticsearch`
-	if [ -n "$pid" ] ; then
-		log_begin_msg "Already running."
-		log_end_msg 0
-		exit 0
-	fi
-
-	# Ensure that the PID_DIR exists (it is cleaned at OS startup time)
-	if [ -n "$PID_DIR" ] && [ ! -e "$PID_DIR" ]; then
-		mkdir -p "$PID_DIR" && chown "$ES_USER":"$ES_GROUP" "$PID_DIR"
-	fi
-	if [ -n "$PID_FILE" ] && [ ! -e "$PID_FILE" ]; then
-		touch "$PID_FILE" && chown "$ES_USER":"$ES_GROUP" "$PID_FILE"
-	fi
-
-	if [ -n "$MAX_OPEN_FILES" ]; then
-		ulimit -n $MAX_OPEN_FILES
-	fi
-
-	if [ -n "$MAX_LOCKED_MEMORY" ]; then
-		ulimit -l $MAX_LOCKED_MEMORY
-	fi
-
-	if [ -n "$MAX_MAP_COUNT" -a -f /proc/sys/vm/max_map_count ]; then
-		sysctl -q -w vm.max_map_count=$MAX_MAP_COUNT
-	fi
-
-	# Start Daemon
-	start-stop-daemon -d $ES_HOME --start --user "$ES_USER" -c "$ES_USER" --pidfile "$PID_FILE" --exec $DAEMON -- $DAEMON_OPTS
-	return=$?
-	if [ $return -eq 0 ]; then
-		i=0
-		timeout=<%= @startup_timeout %>
-		# Wait for the process to be properly started before exiting
-		until { kill -0 `cat "$PID_FILE"`; } >/dev/null 2>&1
-		do
-			sleep 1
-			i=$(($i + 1))
-			if [ $i -gt $timeout ]; then
-				log_end_msg 1
-				exit 1
-			fi
-		done
-	fi
-	log_end_msg $return
-	exit $return
-	;;
-  stop)
-	log_daemon_msg "Stopping $DESC"
-
-	if [ -f "$PID_FILE" ]; then
-		start-stop-daemon --stop --pidfile "$PID_FILE" \
-			--user "$ES_USER" \
-			--quiet \
-			--retry forever/TERM/20 > /dev/null
-		if [ $? -eq 1 ]; then
-			log_progress_msg "$DESC is not running but pid file exists, cleaning up"
-		elif [ $? -eq 3 ]; then
-			PID="`cat $PID_FILE`"
-			log_failure_msg "Failed to stop $DESC (pid $PID)"
-			exit 1
-		fi
-		rm -f "$PID_FILE"
-	else
-		log_progress_msg "(not running)"
-	fi
-	log_end_msg 0
-	;;
-  status)
-	status_of_proc -p $PID_FILE elasticsearch elasticsearch && exit 0 || exit $?
-	;;
-  restart|force-reload)
-	if [ -f "$PID_FILE" ]; then
-		$0 stop
-	fi
-	$0 start
-	;;
-  *)
-	log_success_msg "Usage: $0 {start|stop|restart|force-reload|status}"
-	exit 1
-	;;
-esac
-
-exit 0
+exec /usr/share/elasticsearch/bin/elasticsearch -Epath.logs=<%= @path_logs %> -Epath.data=<%= @path_data %> -Epath.conf=<%= @path_conf %>

--- a/templates/ubuntu/initscript.erb
+++ b/templates/ubuntu/initscript.erb
@@ -156,7 +156,7 @@ case "$1" in
 	return=$?
 	if [ $return -eq 0 ]; then
 		i=0
-		timeout=10
+		timeout=<%= @startup_timeout %>
 		# Wait for the process to be properly started before exiting
 		until { kill -0 `cat "$PID_FILE"`; } >/dev/null 2>&1
 		do


### PR DESCRIPTION
I was able to use the default recipe and and configure everything with role attributes to get elasticsearch working but ran into an issue where `service elasticsearch restart` would always say it failed on starting up the service when it actually didn't. I was able to get through this by extending the timeout to 30 seconds. 

Submitting this PR to parameterize the timeout for the ubuntu/debian initscripts so it's an option we can configure via attributes vs having to roll a new cookbook just for this.

Thanks!