### PR TITLE
remove require_recipe 'chef-sugar' (for master)

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -4,8 +4,6 @@
 # Recipe:: default
 #
 
-include_recipe 'chef-sugar'
-
 # see README.md and test/fixtures/cookbooks for more examples!
 elasticsearch_user 'elasticsearch' do
   node['elasticsearch']['user'].each do |key, value|


### PR DESCRIPTION
chef-sugar::default no longer needs to be included in your runlist. Instead simply depend on the chef-sugar cookbook and the gem will be intalled and loaded automatically.

https://github.com/sethvargo/chef-sugar/blob/master/recipes/default.rb#L20