### PR TITLE
Roll back changes to initscripts and log4j2 properties file

### DIFF
--- a/templates/amazon/initscript.erb
+++ b/templates/amazon/initscript.erb
@@ -33,7 +33,7 @@ fi
 
 # Sets the default values for elasticsearch variables used in this script
 ES_HOME="/usr/share/elasticsearch"
-MAX_OPEN_FILES=65535
+MAX_OPEN_FILES=65536
 MAX_MAP_COUNT=262144
 ES_PATH_CONF="/etc/elasticsearch"
 
@@ -69,7 +69,21 @@ if [ ! -x "$exec" ]; then
     exit 1
 fi
 
+checkJava() {
+    if [ -x "$JAVA_HOME/bin/java" ]; then
+        JAVA="$JAVA_HOME/bin/java"
+    else
+        JAVA=`which java`
+    fi
+
+    if [ ! -x "$JAVA" ]; then
+        echo "Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME"
+        exit 1
+    fi
+}
+
 start() {
+    checkJava
     [ -x $exec ] || exit 5
 
     if [ -n "$MAX_OPEN_FILES" ]; then
@@ -78,7 +92,7 @@ start() {
     if [ -n "$MAX_LOCKED_MEMORY" ]; then
         ulimit -l $MAX_LOCKED_MEMORY
     fi
-    if [ -n "$MAX_MAP_COUNT" -a -f /proc/sys/vm/max_map_count ] && [ "$MAX_MAP_COUNT" -gt $(cat /proc/sys/vm/max_map_count) ]; then
+    if [ -n "$MAX_MAP_COUNT" -a -f /proc/sys/vm/max_map_count ]; then
         sysctl -q -w vm.max_map_count=$MAX_MAP_COUNT
     fi
 

--- a/templates/centos/initscript.erb
+++ b/templates/centos/initscript.erb
@@ -33,7 +33,7 @@ fi
 
 # Sets the default values for elasticsearch variables used in this script
 ES_HOME="/usr/share/elasticsearch"
-MAX_OPEN_FILES=65535
+MAX_OPEN_FILES=65536
 MAX_MAP_COUNT=262144
 ES_PATH_CONF="/etc/elasticsearch"
 
@@ -69,7 +69,21 @@ if [ ! -x "$exec" ]; then
     exit 1
 fi
 
+checkJava() {
+    if [ -x "$JAVA_HOME/bin/java" ]; then
+        JAVA="$JAVA_HOME/bin/java"
+    else
+        JAVA=`which java`
+    fi
+
+    if [ ! -x "$JAVA" ]; then
+        echo "Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME"
+        exit 1
+    fi
+}
+
 start() {
+    checkJava
     [ -x $exec ] || exit 5
 
     if [ -n "$MAX_OPEN_FILES" ]; then
@@ -78,7 +92,7 @@ start() {
     if [ -n "$MAX_LOCKED_MEMORY" ]; then
         ulimit -l $MAX_LOCKED_MEMORY
     fi
-    if [ -n "$MAX_MAP_COUNT" -a -f /proc/sys/vm/max_map_count ] && [ "$MAX_MAP_COUNT" -gt $(cat /proc/sys/vm/max_map_count) ]; then
+    if [ -n "$MAX_MAP_COUNT" -a -f /proc/sys/vm/max_map_count ]; then
         sysctl -q -w vm.max_map_count=$MAX_MAP_COUNT
     fi
 

--- a/templates/debian/initscript.erb
+++ b/templates/debian/initscript.erb
@@ -39,7 +39,7 @@ ES_HOME=/usr/share/$NAME
 #ES_JAVA_OPTS=
 
 # Maximum number of open files
-MAX_OPEN_FILES=65535
+MAX_OPEN_FILES=65536
 
 # Maximum amount of locked memory
 #MAX_LOCKED_MEMORY=
@@ -82,8 +82,22 @@ if [ ! -x "$DAEMON" ]; then
 	exit 1
 fi
 
+checkJava() {
+	if [ -x "$JAVA_HOME/bin/java" ]; then
+		JAVA="$JAVA_HOME/bin/java"
+	else
+		JAVA=`which java`
+	fi
+
+	if [ ! -x "$JAVA" ]; then
+		echo "Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME"
+		exit 1
+	fi
+}
+
 case "$1" in
   start)
+	checkJava
 
 	log_daemon_msg "Starting $DESC"
 
@@ -110,7 +124,7 @@ case "$1" in
 		ulimit -l $MAX_LOCKED_MEMORY
 	fi
 
-	if [ -n "$MAX_MAP_COUNT" -a -f /proc/sys/vm/max_map_count ] && [ "$MAX_MAP_COUNT" -gt $(cat /proc/sys/vm/max_map_count) ]; then
+	if [ -n "$MAX_MAP_COUNT" -a -f /proc/sys/vm/max_map_count ]; then
 		sysctl -q -w vm.max_map_count=$MAX_MAP_COUNT
 	fi
 

--- a/templates/default/log4j2.properties.erb
+++ b/templates/default/log4j2.properties.erb
@@ -7,16 +7,14 @@ logger.action.level = debug
 appender.console.type = Console
 appender.console.name = console
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%marker %m%n
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%m%n
 
-######## Server JSON ############################
 appender.rolling.type = RollingFile
 appender.rolling.name = rolling
-appender.rolling.fileName = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_server.json
-appender.rolling.layout.type = ESJsonLayout
-appender.rolling.layout.type_name = server
-
-appender.rolling.filePattern = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}-%d{yyyy-MM-dd}-%i.json.gz
+appender.rolling.fileName = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}.log
+appender.rolling.layout.type = PatternLayout
+appender.rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%.-10000m%n
+appender.rolling.filePattern = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}-%d{yyyy-MM-dd}-%i.log.gz
 appender.rolling.policies.type = Policies
 appender.rolling.policies.time.type = TimeBasedTriggeringPolicy
 appender.rolling.policies.time.interval = 1
@@ -31,147 +29,60 @@ appender.rolling.strategy.action.condition.type = IfFileName
 appender.rolling.strategy.action.condition.glob = ${sys:es.logs.cluster_name}-*
 appender.rolling.strategy.action.condition.nested_condition.type = IfAccumulatedFileSize
 appender.rolling.strategy.action.condition.nested_condition.exceeds = 2GB
-################################################
-######## Server -  old style pattern ###########
-appender.rolling_old.type = RollingFile
-appender.rolling_old.name = rolling_old
-appender.rolling_old.fileName = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}.log
-appender.rolling_old.layout.type = PatternLayout
-appender.rolling_old.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%marker %m%n
-
-appender.rolling_old.filePattern = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}-%d{yyyy-MM-dd}-%i.log.gz
-appender.rolling_old.policies.type = Policies
-appender.rolling_old.policies.time.type = TimeBasedTriggeringPolicy
-appender.rolling_old.policies.time.interval = 1
-appender.rolling_old.policies.time.modulate = true
-appender.rolling_old.policies.size.type = SizeBasedTriggeringPolicy
-appender.rolling_old.policies.size.size = 128MB
-appender.rolling_old.strategy.type = DefaultRolloverStrategy
-appender.rolling_old.strategy.fileIndex = nomax
-appender.rolling_old.strategy.action.type = Delete
-appender.rolling_old.strategy.action.basepath = ${sys:es.logs.base_path}
-appender.rolling_old.strategy.action.condition.type = IfFileName
-appender.rolling_old.strategy.action.condition.glob = ${sys:es.logs.cluster_name}-*
-appender.rolling_old.strategy.action.condition.nested_condition.type = IfAccumulatedFileSize
-appender.rolling_old.strategy.action.condition.nested_condition.exceeds = 2GB
-################################################
 
 rootLogger.level = info
 rootLogger.appenderRef.console.ref = console
 rootLogger.appenderRef.rolling.ref = rolling
-rootLogger.appenderRef.rolling_old.ref = rolling_old
 
-######## Deprecation JSON #######################
 appender.deprecation_rolling.type = RollingFile
 appender.deprecation_rolling.name = deprecation_rolling
-appender.deprecation_rolling.fileName = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_deprecation.json
-appender.deprecation_rolling.layout.type = ESJsonLayout
-appender.deprecation_rolling.layout.type_name = deprecation
-appender.deprecation_rolling.layout.esmessagefields=x-opaque-id
-
-appender.deprecation_rolling.filePattern = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_deprecation-%i.json.gz
+appender.deprecation_rolling.fileName = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_deprecation.log
+appender.deprecation_rolling.layout.type = PatternLayout
+appender.deprecation_rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%.-10000m%n
+appender.deprecation_rolling.filePattern = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_deprecation-%i.log.gz
 appender.deprecation_rolling.policies.type = Policies
 appender.deprecation_rolling.policies.size.type = SizeBasedTriggeringPolicy
 appender.deprecation_rolling.policies.size.size = 1GB
 appender.deprecation_rolling.strategy.type = DefaultRolloverStrategy
 appender.deprecation_rolling.strategy.max = 4
-#################################################
-######## Deprecation -  old style pattern #######
-appender.deprecation_rolling_old.type = RollingFile
-appender.deprecation_rolling_old.name = deprecation_rolling_old
-appender.deprecation_rolling_old.fileName = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_deprecation.log
-appender.deprecation_rolling_old.layout.type = PatternLayout
-appender.deprecation_rolling_old.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%marker %m%n
 
-appender.deprecation_rolling_old.filePattern = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}\
-  _deprecation-%i.log.gz
-appender.deprecation_rolling_old.policies.type = Policies
-appender.deprecation_rolling_old.policies.size.type = SizeBasedTriggeringPolicy
-appender.deprecation_rolling_old.policies.size.size = 1GB
-appender.deprecation_rolling_old.strategy.type = DefaultRolloverStrategy
-appender.deprecation_rolling_old.strategy.max = 4
-#################################################
 logger.deprecation.name = org.elasticsearch.deprecation
 logger.deprecation.level = warn
 logger.deprecation.appenderRef.deprecation_rolling.ref = deprecation_rolling
-logger.deprecation.appenderRef.deprecation_rolling_old.ref = deprecation_rolling_old
 logger.deprecation.additivity = false
 
-######## Search slowlog JSON ####################
 appender.index_search_slowlog_rolling.type = RollingFile
 appender.index_search_slowlog_rolling.name = index_search_slowlog_rolling
-appender.index_search_slowlog_rolling.fileName = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs\
-  .cluster_name}_index_search_slowlog.json
-appender.index_search_slowlog_rolling.layout.type = ESJsonLayout
-appender.index_search_slowlog_rolling.layout.type_name = index_search_slowlog
-appender.index_search_slowlog_rolling.layout.esmessagefields=message,took,took_millis,total_hits,types,stats,search_type,total_shards,source,id
-
-appender.index_search_slowlog_rolling.filePattern = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs\
-  .cluster_name}_index_search_slowlog-%i.json.gz
+appender.index_search_slowlog_rolling.fileName = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_search_slowlog.log
+appender.index_search_slowlog_rolling.layout.type = PatternLayout
+appender.index_search_slowlog_rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c] %marker%.-10000m%n
+appender.index_search_slowlog_rolling.filePattern = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_search_slowlog-%d{yyyy-MM-dd}.log
 appender.index_search_slowlog_rolling.policies.type = Policies
-appender.index_search_slowlog_rolling.policies.size.type = SizeBasedTriggeringPolicy
-appender.index_search_slowlog_rolling.policies.size.size = 1GB
-appender.index_search_slowlog_rolling.strategy.type = DefaultRolloverStrategy
-appender.index_search_slowlog_rolling.strategy.max = 4
-#################################################
-######## Search slowlog -  old style pattern ####
-appender.index_search_slowlog_rolling_old.type = RollingFile
-appender.index_search_slowlog_rolling_old.name = index_search_slowlog_rolling_old
-appender.index_search_slowlog_rolling_old.fileName = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}\
-  _index_search_slowlog.log
-appender.index_search_slowlog_rolling_old.layout.type = PatternLayout
-appender.index_search_slowlog_rolling_old.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%marker %m%n
+appender.index_search_slowlog_rolling.policies.time.type = TimeBasedTriggeringPolicy
+appender.index_search_slowlog_rolling.policies.time.interval = 1
+appender.index_search_slowlog_rolling.policies.time.modulate = true
 
-appender.index_search_slowlog_rolling_old.filePattern = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}\
-  _index_search_slowlog-%i.log.gz
-appender.index_search_slowlog_rolling_old.policies.type = Policies
-appender.index_search_slowlog_rolling_old.policies.size.type = SizeBasedTriggeringPolicy
-appender.index_search_slowlog_rolling_old.policies.size.size = 1GB
-appender.index_search_slowlog_rolling_old.strategy.type = DefaultRolloverStrategy
-appender.index_search_slowlog_rolling_old.strategy.max = 4
-#################################################
 logger.index_search_slowlog_rolling.name = index.search.slowlog
 logger.index_search_slowlog_rolling.level = trace
 logger.index_search_slowlog_rolling.appenderRef.index_search_slowlog_rolling.ref = index_search_slowlog_rolling
-logger.index_search_slowlog_rolling.appenderRef.index_search_slowlog_rolling_old.ref = index_search_slowlog_rolling_old
 logger.index_search_slowlog_rolling.additivity = false
 
-######## Indexing slowlog JSON ##################
 appender.index_indexing_slowlog_rolling.type = RollingFile
 appender.index_indexing_slowlog_rolling.name = index_indexing_slowlog_rolling
-appender.index_indexing_slowlog_rolling.fileName = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}\
-  _index_indexing_slowlog.json
-appender.index_indexing_slowlog_rolling.layout.type = ESJsonLayout
-appender.index_indexing_slowlog_rolling.layout.type_name = index_indexing_slowlog
-appender.index_indexing_slowlog_rolling.layout.esmessagefields=message,took,took_millis,doc_type,id,routing,source
-
-appender.index_indexing_slowlog_rolling.filePattern = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}\
-  _index_indexing_slowlog-%i.json.gz
+appender.index_indexing_slowlog_rolling.fileName = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_indexing_slowlog.log
+appender.index_indexing_slowlog_rolling.layout.type = PatternLayout
+appender.index_indexing_slowlog_rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c] %marker%.-10000m%n
+appender.index_indexing_slowlog_rolling.filePattern = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_indexing_slowlog-%d{yyyy-MM-dd}.log
 appender.index_indexing_slowlog_rolling.policies.type = Policies
-appender.index_indexing_slowlog_rolling.policies.size.type = SizeBasedTriggeringPolicy
-appender.index_indexing_slowlog_rolling.policies.size.size = 1GB
-appender.index_indexing_slowlog_rolling.strategy.type = DefaultRolloverStrategy
-appender.index_indexing_slowlog_rolling.strategy.max = 4
-#################################################
-######## Indexing slowlog -  old style pattern ##
-appender.index_indexing_slowlog_rolling_old.type = RollingFile
-appender.index_indexing_slowlog_rolling_old.name = index_indexing_slowlog_rolling_old
-appender.index_indexing_slowlog_rolling_old.fileName = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}\
-  _index_indexing_slowlog.log
-appender.index_indexing_slowlog_rolling_old.layout.type = PatternLayout
-appender.index_indexing_slowlog_rolling_old.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%marker %m%n
-
-appender.index_indexing_slowlog_rolling_old.filePattern = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}\
-  _index_indexing_slowlog-%i.log.gz
-appender.index_indexing_slowlog_rolling_old.policies.type = Policies
-appender.index_indexing_slowlog_rolling_old.policies.size.type = SizeBasedTriggeringPolicy
-appender.index_indexing_slowlog_rolling_old.policies.size.size = 1GB
-appender.index_indexing_slowlog_rolling_old.strategy.type = DefaultRolloverStrategy
-appender.index_indexing_slowlog_rolling_old.strategy.max = 4
-#################################################
+appender.index_indexing_slowlog_rolling.policies.time.type = TimeBasedTriggeringPolicy
+appender.index_indexing_slowlog_rolling.policies.time.interval = 1
+appender.index_indexing_slowlog_rolling.policies.time.modulate = true
 
 logger.index_indexing_slowlog.name = index.indexing.slowlog.index
 logger.index_indexing_slowlog.level = trace
 logger.index_indexing_slowlog.appenderRef.index_indexing_slowlog_rolling.ref = index_indexing_slowlog_rolling
-logger.index_indexing_slowlog.appenderRef.index_indexing_slowlog_rolling_old.ref = index_indexing_slowlog_rolling_old
 logger.index_indexing_slowlog.additivity = false
+
+<% @logging.each do |k,v| %>
+<%= k %>=<%= v %>
+<% end %>

--- a/templates/default/systemd_unit.erb
+++ b/templates/default/systemd_unit.erb
@@ -5,13 +5,10 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-Type=notify
 RuntimeDirectory=elasticsearch
-PrivateTmp=true
 Environment=ES_HOME=/usr/share/elasticsearch
 Environment=ES_PATH_CONF=/etc/elasticsearch
 Environment=PID_DIR=/var/run/elasticsearch
-Environment=ES_SD_NOTIFY=true
 EnvironmentFile=-<%= @default_dir %>/<%= @program_name %>
 
 WorkingDirectory=<%= @path_home %>
@@ -31,7 +28,7 @@ StandardOutput=journal
 StandardError=inherit
 
 # Specifies the maximum file descriptor number that can be opened by this process
-LimitNOFILE=65535
+LimitNOFILE=65536
 
 # Specifies the maximum number of processes
 LimitNPROC=4096
@@ -60,4 +57,4 @@ SuccessExitStatus=143
 [Install]
 WantedBy=multi-user.target
 
-# Built by elasticsearch chef cookbook for elasticsearch version <%= @version %>
+# Built for distribution-6.0.0 (distribution)

--- a/templates/oracle/initscript.erb
+++ b/templates/oracle/initscript.erb
@@ -33,7 +33,7 @@ fi
 
 # Sets the default values for elasticsearch variables used in this script
 ES_HOME="/usr/share/elasticsearch"
-MAX_OPEN_FILES=65535
+MAX_OPEN_FILES=65536
 MAX_MAP_COUNT=262144
 ES_PATH_CONF="/etc/elasticsearch"
 
@@ -69,7 +69,21 @@ if [ ! -x "$exec" ]; then
     exit 1
 fi
 
+checkJava() {
+    if [ -x "$JAVA_HOME/bin/java" ]; then
+        JAVA="$JAVA_HOME/bin/java"
+    else
+        JAVA=`which java`
+    fi
+
+    if [ ! -x "$JAVA" ]; then
+        echo "Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME"
+        exit 1
+    fi
+}
+
 start() {
+    checkJava
     [ -x $exec ] || exit 5
 
     if [ -n "$MAX_OPEN_FILES" ]; then
@@ -78,7 +92,7 @@ start() {
     if [ -n "$MAX_LOCKED_MEMORY" ]; then
         ulimit -l $MAX_LOCKED_MEMORY
     fi
-    if [ -n "$MAX_MAP_COUNT" -a -f /proc/sys/vm/max_map_count ] && [ "$MAX_MAP_COUNT" -gt $(cat /proc/sys/vm/max_map_count) ]; then
+    if [ -n "$MAX_MAP_COUNT" -a -f /proc/sys/vm/max_map_count ]; then
         sysctl -q -w vm.max_map_count=$MAX_MAP_COUNT
     fi
 

--- a/templates/redhat/initscript.erb
+++ b/templates/redhat/initscript.erb
@@ -33,7 +33,7 @@ fi
 
 # Sets the default values for elasticsearch variables used in this script
 ES_HOME="/usr/share/elasticsearch"
-MAX_OPEN_FILES=65535
+MAX_OPEN_FILES=65536
 MAX_MAP_COUNT=262144
 ES_PATH_CONF="/etc/elasticsearch"
 
@@ -69,7 +69,21 @@ if [ ! -x "$exec" ]; then
     exit 1
 fi
 
+checkJava() {
+    if [ -x "$JAVA_HOME/bin/java" ]; then
+        JAVA="$JAVA_HOME/bin/java"
+    else
+        JAVA=`which java`
+    fi
+
+    if [ ! -x "$JAVA" ]; then
+        echo "Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME"
+        exit 1
+    fi
+}
+
 start() {
+    checkJava
     [ -x $exec ] || exit 5
 
     if [ -n "$MAX_OPEN_FILES" ]; then
@@ -78,7 +92,7 @@ start() {
     if [ -n "$MAX_LOCKED_MEMORY" ]; then
         ulimit -l $MAX_LOCKED_MEMORY
     fi
-    if [ -n "$MAX_MAP_COUNT" -a -f /proc/sys/vm/max_map_count ] && [ "$MAX_MAP_COUNT" -gt $(cat /proc/sys/vm/max_map_count) ]; then
+    if [ -n "$MAX_MAP_COUNT" -a -f /proc/sys/vm/max_map_count ]; then
         sysctl -q -w vm.max_map_count=$MAX_MAP_COUNT
     fi
 

--- a/templates/ubuntu/initscript.erb
+++ b/templates/ubuntu/initscript.erb
@@ -39,7 +39,7 @@ ES_HOME=/usr/share/$NAME
 #ES_JAVA_OPTS=
 
 # Maximum number of open files
-MAX_OPEN_FILES=65535
+MAX_OPEN_FILES=65536
 
 # Maximum amount of locked memory
 #MAX_LOCKED_MEMORY=
@@ -82,8 +82,22 @@ if [ ! -x "$DAEMON" ]; then
 	exit 1
 fi
 
+checkJava() {
+	if [ -x "$JAVA_HOME/bin/java" ]; then
+		JAVA="$JAVA_HOME/bin/java"
+	else
+		JAVA=`which java`
+	fi
+
+	if [ ! -x "$JAVA" ]; then
+		echo "Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME"
+		exit 1
+	fi
+}
+
 case "$1" in
   start)
+	checkJava
 
 	log_daemon_msg "Starting $DESC"
 
@@ -110,7 +124,7 @@ case "$1" in
 		ulimit -l $MAX_LOCKED_MEMORY
 	fi
 
-	if [ -n "$MAX_MAP_COUNT" -a -f /proc/sys/vm/max_map_count ] && [ "$MAX_MAP_COUNT" -gt $(cat /proc/sys/vm/max_map_count) ]; then
+	if [ -n "$MAX_MAP_COUNT" -a -f /proc/sys/vm/max_map_count ]; then
 		sysctl -q -w vm.max_map_count=$MAX_MAP_COUNT
 	fi
 


### PR DESCRIPTION
* The new systemd template instructs the ES service to send a notification message to systemd, but the logic to do this is not included in ES 6.x. Reverting this change as it cause the service to timeout and fail. 

* The ESJsonLayout now used in the default log4j properties template is not available in ES 6.x. This triggers the error "ERROR Unable to locate plugin type for ESJsonLayout". 

See the change introducing the ESJsonLayout below.

elastic/elasticsearch@891320f

* Also rolling back the changes to initscripts as java is not bundled with es 6.x and the java check is still needed. 