### PR TITLE
relax elasticsearch version restriction

### DIFF
--- a/libraries/provider_install.rb
+++ b/libraries/provider_install.rb
@@ -53,15 +53,9 @@ class ElasticsearchCookbook::InstallProvider < Chef::Provider::LWRPBase
       end
     end
 
-    if !new_resource.version.nil? && %w[rhel amazon].include?(node['platform_family']) && !new_resource.version.include?('-')
-      # NB: yum repo packages are broken in Chef if you don't specify a release
-      #     https://github.com/chef/chef/issues/4103
-      new_resource.version = "#{new_resource.version}-1"
-    end
-
     pkg_r = package 'elasticsearch' do
+      package_name "elasticsearch-#{new_resource.version}" if new_resource.version
       options new_resource.package_options
-      version new_resource.version
       action :nothing
     end
 
@@ -83,8 +77,8 @@ class ElasticsearchCookbook::InstallProvider < Chef::Provider::LWRPBase
     end
 
     pkg_r = package 'elasticsearch' do
+      package_name "elasticsearch-#{new_resource.version}" if new_resource.version
       options new_resource.package_options
-      version new_resource.version
       action :nothing
     end
     pkg_r.run_action(:remove)


### PR DESCRIPTION
it don't work on centos 8 due to dnf_package bug
```ruby
package 'elasticsearch' do
  version '7.8.1-1'
end
```

while it works:
```ruby
package 'elasticsearch' do
  package_name 'elasticsearch-7.8.1'
end
```
