### PR TITLE
Provide additional package_name parameter for install

### DIFF
--- a/libraries/provider_install.rb
+++ b/libraries/provider_install.rb
@@ -59,7 +59,7 @@ class ElasticsearchCookbook::InstallProvider < Chef::Provider::LWRPBase
       new_resource.version = "#{new_resource.version}-1"
     end
 
-    pkg_r = package 'elasticsearch' do
+    pkg_r = package new_resource.package_name do
       options new_resource.package_options
       version new_resource.version
       action :nothing
@@ -82,7 +82,7 @@ class ElasticsearchCookbook::InstallProvider < Chef::Provider::LWRPBase
       end
     end
 
-    pkg_r = package 'elasticsearch' do
+    pkg_r = package new_resource.package_name do
       options new_resource.package_options
       version new_resource.version
       action :nothing

--- a/libraries/resource_install.rb
+++ b/libraries/resource_install.rb
@@ -23,6 +23,9 @@ class ElasticsearchCookbook::InstallResource < Chef::Resource::LWRPBase
   # where to install?
   attribute(:dir, kind_of: String, default: '/usr/share')
 
+  # package name to use when installing with package provider
+  attribute(:package_name, kind_of: String, default: 'elasticsearch')
+
   # attributes used by the package-flavor provider
   attribute(:package_options, kind_of: String)
 


### PR DESCRIPTION
Closes 751

The cookbook does not allow the installation of elasticsearch-oss packages and builds with a custom names. This PR adds a parameter to the install provider to allow their usage