### PR TITLE
Automated PR: Cookstyle Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+- resolved cookstyle error: Rakefile:1:1 convention: `Style/Encoding`
+- resolved cookstyle error: Rakefile:63:5 convention: `Style/StderrPuts`
+
 ## [v4.3.0](https://github.com/elastic/cookbook-elasticsearch/tree/v4.3.0) (2019-12-30)
 - Default to Elasticsearch 7.4.2
 

--- a/Rakefile
+++ b/Rakefile
@@ -60,7 +60,7 @@ begin
   end
 rescue Exception => e
   if e.class.to_s =~ /^Timeout::|^Kitchen::|LoadError/
-    STDERR.puts "[!] Omitting Kitchen tasks [#{e.class}: #{e.message} at #{e.backtrace.first}]\n\n"
+    warn "[!] Omitting Kitchen tasks [#{e.class}: #{e.message} at #{e.backtrace.first}]\n\n"
   else
     raise e
   end


### PR DESCRIPTION
Hey!
I ran Cookstyle 7.32.1 against this repo and here are the results.
This repo was selected due to the topics of chef-cookbook

## Changes

### Issues found and resolved with Rakefile

 - 1:1 convention: `Style/Encoding` - Unnecessary utf-8 encoding comment. (https://rubystyle.guide#utf-8)
 - 63:5 convention: `Style/StderrPuts` - Use `warn` instead of `STDERR.puts` to allow such output to be disabled. (https://rubystyle.guide#warn)