### PR TITLE
Fix install package to work with custom download_checksum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix property references in install resource
+
 ## 5.1.9 - *2023-10-31*
 
 ## 5.1.8 - *2023-10-31*

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -16,8 +16,8 @@ action :install do
     elasticsearch_install_package "ElasticSearch #{new_resource.version}" do
       version new_resource.version
       instance_name new_resource.instance_name
-      download_url download_url
-      download_checksum download_checksum
+      download_url new_resource.download_url
+      download_checksum new_resource.download_checksum
     end
   when 'repository'
     elasticsearch_install_repository "ElasticSearch #{new_resource.version}" do
@@ -42,6 +42,6 @@ action :remove do
       action :remove
     end
   else
-    raise "#{install_type} is not a valid install type"
+    raise "#{new_resource.type} is not a valid install type"
   end
 end

--- a/resources/partial/_package.rb
+++ b/resources/partial/_package.rb
@@ -1,7 +1,7 @@
 property :download_url,
         String,
-        default: lazy { default_download_url(new_resource.version) }
+        default: lazy { default_download_url(version) }
 
 property :download_checksum,
         String,
-        default: lazy { default_download_checksum(new_resource.version)[checksum_platform] }
+        default: lazy { default_download_checksum(version)[checksum_platform] }


### PR DESCRIPTION
# Description
Fix install package to work with custom download_checksum. Currently you cannot specify the download_url or download_checksum so you cannot install newer versions then what already exists!

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
