### PR TITLE
[GH-802] Fix to remove hard coded version 7 for Debian repository

### DIFF
--- a/resources/install_repository.rb
+++ b/resources/install_repository.rb
@@ -16,7 +16,7 @@ action :install do
   if new_resource.enable_repository_actions
     if platform_family?('debian')
       apt_repository "elastic-#{major_version}.x" do
-        uri 'https://artifacts.elastic.co/packages/7.x/apt'
+        uri "https://artifacts.elastic.co/packages/#{major_version}.x/apt"
         key 'elasticsearch.asc'
         cookbook 'elasticsearch'
         components ['main']


### PR DESCRIPTION
obvious fix

# Description

Remove hard coded version 7 for Debian repository installation

## Issues Resolved

[GH-802]

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
